### PR TITLE
Update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,34 @@ make venv # Create a virtualenv and install pip-tools
 make dev # Set-up dev environment
 ```
 
+### Running the tests
+
+We use [pytest](https://docs.pytest.org/en/latest/) for testing. There are
+three sets of tests in the API Client:
+
+- **Regular Tests**: invokes a mocked API and can be run offline
+- **Web Tests** (`web`): hits the external server and requires an API token.
+- **Contract Tests** (`contract`): checks for consistency of mocked data to live data. 
+
+All contract tests are web tests. It is recommended that external developers
+write both regular and web tests, but locally do their checks on regular tests.
+Web tests should only be handled by a continuous integration service (via a
+testing account), unless you want to use your own API token.
+
+To run regular tests:
+
+```shell
+# In project root
+pytest -m "not webtest" -v
+```
+
+Lastly, to run all tests:
+
+```shell
+# In project root
+pytest -v
+```
+
 ## License
 
 MIT License (c) 2018, Thinking Machines Data Science

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -122,6 +122,7 @@ you can add pre-commit hooks for both flake8 and black to make all formatting ea
 
 7. Submit a pull request through the GitHub website.
 
+
 Contributor Guidelines
 ----------------------
 
@@ -142,3 +143,30 @@ Coding Standards
 
 * We use PEP8 as our coding standard
 * In addition, we use `black <https://github.com/ambv/black>`_ as our code formatter
+
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+We use `pytest <https://docs.pytest.org/en/latest/>`_ for testing. There
+are three sets of tests in the API Client:
+
+- **Regular Tests**: invokes a mocked API and can be run offline
+- **Web Tests** (`web`): hits the external server and requires an API token.
+- **Contract Tests** (`contract`): checks for consistency of mocked data to live data. 
+
+All contract tests are web tests. It is recommended that external developers
+write both regular and web tests, but locally do their checks on regular tests.
+Web tests should only be handled by a continuous integration service (via a
+testing account), unless you want to use your own API token.
+
+
+.. code-block:: shell
+   # In project root
+   pytest -m "not webtest" -v
+
+Lastly, to run all tests:
+
+.. code-block:: shell
+   # In project root
+   pytest -v

--- a/linksight/resource/base.py
+++ b/linksight/resource/base.py
@@ -3,11 +3,15 @@
 # Import standard library
 import logging
 
-# Import modules
+# Import from package
 import coloredlogs
 
 from ..common.settings import ENDPOINT
 from ..common.utils import urljoin
+
+# Create a logger
+logger = logging.getLogger(__name__)
+coloredlogs.install(level=logging.INFO, logger=logger)
 
 
 class Resource(dict):
@@ -57,9 +61,6 @@ class Resource(dict):
         super().__init__(resp.json())
         self.client = client
         self.response = resp
-        # Create a logger
-        self.logger = logging.getLogger(__name__)
-        coloredlogs.install(level=logging.INFO, logger=self.logger)
 
     def create_instance_url(self, *args):
         """Create the instance url to pass the request onto

--- a/linksight/resource/resources.py
+++ b/linksight/resource/resources.py
@@ -2,7 +2,17 @@
 
 """Contains various resources for API calls"""
 
+# Import standard library
+import logging
+
+# Import from package
+import coloredlogs
+
 from ..resource.base import Resource
+
+# Create a logger
+logger = logging.getLogger(__name__)
+coloredlogs.install(level=logging.INFO, logger=logger)
 
 
 class User(Resource):
@@ -49,7 +59,7 @@ class Dataset(Resource):
         """
         if not any([source_bgy_col, source_municity_col, source_prov_col]):
             msg = 'At least one column must be defined!'
-            self.logger.error(msg)
+            logger.error(msg)
             raise ValueError(msg)
         url = self.create_instance_url('match')
         json_request = {

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,6 +2,7 @@
 # Testing
 python-dotenv==0.9.1
 pytest==3.6.4
+responses
 flake8==3.5.0
 tox
 # Documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ imagesize==1.1.0
 jinja2==2.10
 markupsafe==1.1.0
 mccabe==0.6.1
-more-itertools==4.3.0
+more-itertools==5.0.0
 numpy==1.15.4
 packaging==18.0
 pandas==0.23.4
@@ -30,6 +30,7 @@ python-dateutil==2.7.5
 python-dotenv==0.9.1
 pytz==2018.7
 requests==2.21.0
+responses==0.10.5
 six==1.12.0
 snowballstemmer==1.2.1
 sphinx-rtd-theme==0.4.2
@@ -39,4 +40,4 @@ sphinxcontrib-websupport==1.1.0
 toml==0.10.0
 tox==3.6.1
 urllib3==1.24.1
-virtualenv==16.1.0
+virtualenv==16.2.0

--- a/settings.py
+++ b/settings.py
@@ -3,10 +3,10 @@
 """Settings for python-dotenv"""
 
 # Import standard library
-import os
+from pathlib import Path
 
 # Import from package
 from dotenv import load_dotenv
 
-dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
+env_path = Path('.') / '.env'
 load_dotenv(verbose=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,12 @@ import os
 
 # Import modules
 import pytest
+import responses
 
 # Import from package
 import linksight
+from linksight.common.settings import ENDPOINT
+from linksight.common.utils import urljoin
 
 API_TOKEN = os.getenv('API_TOKEN')
 
@@ -16,3 +19,66 @@ API_TOKEN = os.getenv('API_TOKEN')
 def client():
     """Return a client"""
     return linksight.Client(API_TOKEN)
+
+
+@pytest.fixture
+def user_response():
+    """Return the expected response for the user resource"""
+    return {
+        'username': 'thinkdatasci',
+        'email': 'hello@thinkingmachin.es',
+        'first_name': 'Thinking Machines',
+        'last_name': 'Data Science',
+    }
+
+
+@pytest.fixture
+def dataset_response():
+    """Return the expected response for the dataset resource"""
+    return {
+        'id': '6937ce41-ab13-412a-f52e-7f5b435a6ed7',
+        'file': 'https://storage.googleapis.com/linksight/datasets/test_areas_V8u4xEO.csv',  # NOQA
+        'name': 'test_areas.csv',
+        'is_internal': False,
+        'created_at': '2018-12-29T13:34:24.257835+08:00',
+        'uploader': 6,
+    }
+
+
+@pytest.fixture
+def match_response(dataset_response):
+    """Return the expected response for a match resource"""
+    return {
+        'id': 'f195903b-6c7d-4290-8320-ce5ce5af3b5c',
+        'source_bgy_col': None,
+        'source_municity_col': None,
+        'source_prov_col': 'Province',
+        'created_at': '2018-12-29T13:34:24.257835+08:00',
+        'dataset': dataset_response,
+        'matched_dataset': {
+            'id': 'f2286737-87ec-4a16-8434-23b2620a548f',
+            'file': 'https://storage.googleapis.com/linksight/datasets/test_areas-linksight_d7UH5fY.csv',  # NOQA
+            'name': 'test_areas-linksight.csv',
+            'is_internal': False,
+            'created_at': '2018-12-29T13:36:56.493743+08:00',
+            'uploader': None,
+        },
+    }
+
+
+@pytest.fixture
+def mock_api(user_response, dataset_response, match_response):
+    """Return a mocked external API"""
+    # Manage endpoints
+    user_endpt = urljoin(ENDPOINT, 'users', 'me')
+    dataset_endpt = urljoin(ENDPOINT, 'datasets')
+    match_endpt = urljoin(
+        ENDPOINT, 'datasets', dataset_response['id'], 'match'
+    )
+    # Set assert_all_requests_are_fired=False so that we can add
+    # multiples responses w/o the need to request them in one test
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.add(responses.GET, url=user_endpt, json=user_response)
+        rsps.add(responses.POST, url=dataset_endpt, json=dataset_response)
+        rsps.add(responses.POST, url=match_endpt, json=match_response)
+        yield rsps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,14 @@ import os
 # Import modules
 import pytest
 import responses
+from dotenv import load_dotenv
 
 # Import from package
 import linksight
 from linksight.common.settings import ENDPOINT
 from linksight.common.utils import urljoin
 
+load_dotenv()
 API_TOKEN = os.getenv('API_TOKEN')
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,42 +1,30 @@
 # -*- coding: utf-8 -*-
 
-"""Tests all methods on Client
-
-For tests involving mock-methods, we are mocking the methods of the Resource
-being consumed. For example, in get_user(), we are mocking the resource
-User.retrieve() then check if Client really returns the "retrieved" value.
-"""
+"""Tests all methods on Client"""
 
 # Import standard library
-from unittest.mock import patch
 import glob
 
+# Import modules
+import responses
+
 # Import from package
-import linksight
+import linksight as ls
+from linksight.common.settings import ENDPOINT
+from linksight.common.utils import urljoin
 
 
-@patch.object(linksight.client.User, 'retrieve')
-def test_client_get_user_return_value(mock_user_retrieve, client):
-    """Test if Client.get_user() returns the expected value"""
-    # Mock return value
-    user_info = {
-        'username': 'mock-data',
-        'email': 'email@mock.org',
-        'first_name': 'mock',
-        'last_name': 'data',
-    }
-    # Test proper
-    mock_user_retrieve.return_value = user_info
-    assert mock_user_retrieve() == client.get_user()
+def test_client_get_user(mock_api, client, user_response):
+    """Test if Client.get_user() returns the expected value and type"""
+    resp = client.get_user()
+    assert isinstance(resp, ls.resource.resources.User)
+    assert resp.keys() == user_response.keys()
 
 
-@patch.object(linksight.client.Dataset, 'create')
-def test_client_create_dataset_return_value(mock_ds_create, client):
-    """Test if Client.create_dataset() returns the expected value"""
-    # Mock return value
-    dataset = {'file': 'gs://mock-data/mock-output.csv'}
-    mock_ds_create.return_value = dataset
-    # Test proper
-    test_data = glob.glob('./**/data/test_areas.csv', recursive=True)
-    with open(test_data[0], 'r') as f:
-        assert mock_ds_create() == client.create_dataset(f)
+def test_client_create_dataset(mock_api, client, dataset_response):
+    """Test if Client.create_dataset() returns the expected value and type"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        resp = client.create_dataset(fp)
+    assert isinstance(resp, ls.resource.resources.Dataset)
+    assert resp.keys() == dataset_response.keys()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,12 +6,10 @@
 import glob
 
 # Import modules
-import responses
+import pytest
 
 # Import from package
 import linksight as ls
-from linksight.common.settings import ENDPOINT
-from linksight.common.utils import urljoin
 
 
 def test_client_get_user(mock_api, client, user_response):
@@ -28,3 +26,19 @@ def test_client_create_dataset(mock_api, client, dataset_response):
         resp = client.create_dataset(fp)
     assert isinstance(resp, ls.resource.resources.Dataset)
     assert resp.keys() == dataset_response.keys()
+
+
+@pytest.mark.webtest
+def test_client_get_user_web(client):
+    """Test if Client.get_user() returns the expected type"""
+    resp = client.get_user()
+    assert isinstance(resp, ls.resource.resources.User)
+
+
+@pytest.mark.webtest
+def test_client_create_dataset_web(client):
+    """Test if Client.create_dataset() returns the expected value and type"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        resp = client.create_dataset(fp)
+    assert isinstance(resp, ls.resource.resources.Dataset)

--- a/tests/test_integration_contract.py
+++ b/tests/test_integration_contract.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+"""Tests if the mock data in conftest is consistent with the live server
+
+Our mock data lies on the assumption that the responses will be the same as
+with the external API. However, LinkSight's response may change throughout its
+development cycle. This set of tests simply checks for consistency
+"""
+
+# Import standard library
+import glob
+
+# Import modules
+import pytest
+
+
+@pytest.mark.contract
+@pytest.mark.webtest
+def test_user_responsse(user_response, client):
+    """Test contract for user response"""
+    resp = client.get_user()
+    assert resp.keys() == user_response.keys()
+
+
+@pytest.mark.contract
+@pytest.mark.webtest
+def test_dataset_response(dataset_response, client):
+    """Test contract for dataset response"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        resp = client.create_dataset(fp)
+    assert resp.keys() == dataset_response.keys()
+
+
+@pytest.mark.contract
+@pytest.mark.webtest
+def test_match_response(match_response, client):
+    """Test contract for match response"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        ds = client.create_dataset(fp)
+    resp = ds.match(source_prov_col='Province')
+    assert resp.keys() == match_response.keys()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+"""Tests all methods on Client"""
+
+# Import standard library
+import glob
+
+# Import modules
+import responses
+
+# Import from package
+import linksight as ls
+from linksight.common.settings import ENDPOINT
+from linksight.common.utils import urljoin
+
+
+def test_dataset_match(mock_api, client, match_response):
+    """Test if Dataset.match() returns the expected value and type"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        ds = client.create_dataset(fp)
+    resp = ds.match(
+            source_prov_col='Province'
+            )
+    assert isinstance(resp, ls.resource.resources.Match)
+    assert resp.keys() == match_response.keys()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -6,12 +6,10 @@
 import glob
 
 # Import modules
-import responses
+import pytest
 
 # Import from package
 import linksight as ls
-from linksight.common.settings import ENDPOINT
-from linksight.common.utils import urljoin
 
 
 def test_dataset_match(mock_api, client, match_response):
@@ -19,8 +17,16 @@ def test_dataset_match(mock_api, client, match_response):
     file = glob.glob('./**/test_areas.csv', recursive=True)
     with open(file[0], 'r') as fp:
         ds = client.create_dataset(fp)
-    resp = ds.match(
-            source_prov_col='Province'
-            )
+    resp = ds.match(source_prov_col='Province')
     assert isinstance(resp, ls.resource.resources.Match)
     assert resp.keys() == match_response.keys()
+
+
+@pytest.mark.webtest
+def test_dataset_match_web(client):
+    """Test if Dataset.match() returns the expected type"""
+    file = glob.glob('./**/test_areas.csv', recursive=True)
+    with open(file[0], 'r') as fp:
+        ds = client.create_dataset(fp)
+    resp = ds.match(source_prov_col='Province')
+    assert isinstance(resp, ls.resource.resources.Match)


### PR DESCRIPTION
Reference #19 

## On testing

There are three sets of tests in the API Client:

- **Regular Tests**: invokes a mocked API and can be run offline
- **Web Tests** (`web`): hits the external server and requires an API token.
- **Contract Tests** (`contract`): checks for consistency of mocked data to live data. 

All contract tests are web tests. It is recommended that external developers write both regular and web tests, but locally do their checks on regular tests. Web tests should only be handled by a continuous integration service (via a testing account), unless you want to use your own API token.

To run regular tests:

```shell
# In project root
pytest -m "not webtest and not contract" -v
```

Lastly, to run all tests:

```shell
# In project root
pytest -v
```

Ideally, mock tests should be used for PRs, commits, etc. Then we should run web tests and the integrity checks in a certain interval (via cron job?) to ensure that everything is consistent with the external API