### PR TITLE
Change endpoint to prod

### DIFF
--- a/linksight/common/settings.py
+++ b/linksight/common/settings.py
@@ -12,4 +12,4 @@ interaction with the LinkSight API. These constants include:
 
 VERSION = '0.1'
 USER_AGENT = 'linksight-api-client/{}'.format(VERSION)
-ENDPOINT = 'https://linksight-stg.thinkingmachin.es/api'
+ENDPOINT = 'https://linksight.thinkingmachin.es/api'


### PR DESCRIPTION
Changed endpoint from `linksight-stg` to `linksight`, getting 403 errors.
Two possible solutions:
- Either fix the misalignment in staging, or
- Add API endpoints to prod

cc: @marksteve 